### PR TITLE
Fix biased bananajack shuffle

### DIFF
--- a/cmds/bananajack.js
+++ b/cmds/bananajack.js
@@ -82,13 +82,14 @@ module.exports.run = async (bot, message, args, guild) => {
           }
 
           function shuffleDeck(deck) {
-            for (let i = 0; i < deck.length; i++) {
-              //create a for loop and loop through every card in the deck.
-              let swapIndex = Math.trunc(Math.random() * deck.length); //calculate and index of a card we can swap with eg. card #1 and swap with any random card within the 52 cards between [0] and [51] then remove decimals with trunc
-              let tmp = deck[swapIndex];
-              deck[swapIndex] = deck[i];
+            // Fisher-Yates shuffle with Durstenfeld's improvement.
+            for (let i = 0; i < deck.length - 1; i++) {
+              // i <= j < deck.length
+              let j = i + Math.trunc(Math.random() * (deck.length - i));
+              // Swap deck[i] and deck[j]:
+              let tmp = deck[j];
+              deck[j] = deck[i];
               deck[i] = tmp;
-              //swap deck subscript i with deck subscript swapIndex so will temporarily hold onto deck swapIndex and then deck swapIndex will set that to deck i and then will set deck i to our tmp variable hence we are swapping deck i with deck swapIndex hence shuffling the entire deck.
             }
           }
 


### PR DESCRIPTION
Use a Fisher-Yates shuffle instead of a (biased) 52^52 shuffle.
The biased shuffle raises the expected value of the
starting hands slightly, particularly for the dealer.  As an
example, the dealer's first card is K♥ with 2.6% probability
and 2♠ with only 1.43%, while the unbiased probability of any
card with the correct algorithm is 1.92%.

See also:
https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Implementation_errors